### PR TITLE
Fix: short verbose -v as boolean flag; parity with --verbose (no arg) [swev-id: pylint-dev__pylint-6386]

### DIFF
--- a/pylint/config/utils.py
+++ b/pylint/config/utils.py
@@ -218,6 +218,12 @@ def _preprocess_options(run: Run, args: Sequence[str]) -> list[str]:
     i = 0
     while i < len(args):
         argument = args[i]
+
+        # Handle short -v same as --verbose (early effect without argument)
+        if argument == "-v":
+            _set_verbose_mode(run, None)
+            i += 1
+            continue
         if not argument.startswith("--"):
             processed_args.append(argument)
             i += 1

--- a/pylint/lint/base_options.py
+++ b/pylint/lint/base_options.py
@@ -538,8 +538,8 @@ def _make_run_options(self: Run) -> Options:
         (
             "verbose",
             {
-                "action": _DoNothingAction,
-                "kwargs": {},
+                "action": "store_true",
+                "default": False,
                 "short": "v",
                 "help": "In verbose mode, extra non-checker-related info "
                 "will be displayed.",

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -148,7 +148,6 @@ def test_pylintrc_parentdir_no_package() -> None:
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_verbose_output_no_config(capsys: CaptureFixture) -> None:
     """Test that we print a log message in verbose mode with no file."""
-
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_verbose_output_no_config_short(capsys: CaptureFixture) -> None:
     """Test that we print a log message in verbose mode with -v and no file."""
@@ -159,16 +158,6 @@ def test_verbose_output_no_config_short(capsys: CaptureFixture) -> None:
             os.chdir(chroot_path / "a/b/c")
             with pytest.raises(SystemExit):
                 Run(["-v"])
-            out = capsys.readouterr()
-            assert "No config file found, using default configuration" in out.err
-
-    with tempdir() as chroot:
-        with fake_home():
-            chroot_path = Path(chroot)
-            testutils.create_files(["a/b/c/d/__init__.py"])
-            os.chdir(chroot_path / "a/b/c")
-            with pytest.raises(SystemExit):
-                Run(["--verbose"])
             out = capsys.readouterr()
             assert "No config file found, using default configuration" in out.err
 

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -148,6 +148,15 @@ def test_pylintrc_parentdir_no_package() -> None:
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_verbose_output_no_config(capsys: CaptureFixture) -> None:
     """Test that we print a log message in verbose mode with no file."""
+    with tempdir() as chroot:
+        with fake_home():
+            chroot_path = Path(chroot)
+            testutils.create_files(["a/b/c/d/__init__.py"])
+            os.chdir(chroot_path / "a/b/c")
+            with pytest.raises(SystemExit):
+                Run(["--verbose"])
+            out = capsys.readouterr()
+            assert "No config file found, using default configuration" in out.err
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_verbose_output_no_config_short(capsys: CaptureFixture) -> None:
     """Test that we print a log message in verbose mode with -v and no file."""

--- a/tests/config/test_find_default_config_files.py
+++ b/tests/config/test_find_default_config_files.py
@@ -148,6 +148,20 @@ def test_pylintrc_parentdir_no_package() -> None:
 @pytest.mark.usefixtures("pop_pylintrc")
 def test_verbose_output_no_config(capsys: CaptureFixture) -> None:
     """Test that we print a log message in verbose mode with no file."""
+
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_verbose_output_no_config_short(capsys: CaptureFixture) -> None:
+    """Test that we print a log message in verbose mode with -v and no file."""
+    with tempdir() as chroot:
+        with fake_home():
+            chroot_path = Path(chroot)
+            testutils.create_files(["a/b/c/d/__init__.py"])
+            os.chdir(chroot_path / "a/b/c")
+            with pytest.raises(SystemExit):
+                Run(["-v"])
+            out = capsys.readouterr()
+            assert "No config file found, using default configuration" in out.err
+
     with tempdir() as chroot:
         with fake_home():
             chroot_path = Path(chroot)

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1430,6 +1430,13 @@ class TestCallbackOptions:
             assert run.verbose
 
     @staticmethod
+    def test_verbose_short() -> None:
+        """Test the -v flag behaves like --verbose."""
+        with pytest.raises(SystemExit):
+            run = Run(["-v"])
+            assert run.verbose
+
+    @staticmethod
     def test_enable_all_extensions() -> None:
         """Test to see if --enable-all-extensions does indeed load all extensions."""
         # Record all extensions


### PR DESCRIPTION
### Summary
Fix the short verbose option `-v` to behave like the long option `--verbose` (boolean flag, no argument). Also preprocess `-v` for early verbose behavior, matching `--verbose`.

Linked Issue: #26

### Root cause
- `verbose` was registered with a custom argparse action (`_DoNothingAction`) without `nargs`, which makes argparse expect a value for `-v/--verbose`.
- The preprocessor in `pylint/config/utils.py` only handled `--verbose`, not `-v`. Thus, `-v` flowed into argparse and failed with “expected one argument”.

### Changes
- `pylint/lint/base_options.py`: define `verbose` as `action="store_true"`, `default=False`, keep short `-v` and help, hide from config file.
- `pylint/config/utils.py`: preprocess `-v` like `--verbose` for early effect.
- Tests: add coverage for `-v` flag and early verbose output.

### Reproduction steps (before fix)
1. Create a file `mytest.py`:
   ```python
   print("ok")
   ```
2. Run:
   ```shell
   pylint mytest.py -v
   ```
3. Observed failure:
   ```
   usage: pylint [options]
   pylint: error: argument --verbose/-v: expected one argument
   ```

### Behavior after fix
- `pylint mytest.py -v` works the same as `pylint mytest.py --verbose` (no argument required); early verbose messages (e.g., about config file discovery) are shown for `-v` too.
- `--verbose=<value>` remains invalid and raises `SystemExit` via the preprocessor.

### Notes
- No CI was triggered manually per request.
- Local environment used Python 3.11; in case of environment constraints, Python 3.10 is recommended for this branch as the original report referenced 3.10.