### PR TITLE
swev-id: pylint-dev__pylint-4604 fix unused-import for type comments

### DIFF
--- a/pylint/checkers/variables.py
+++ b/pylint/checkers/variables.py
@@ -1675,6 +1675,11 @@ class VariablesChecker(BaseChecker):
                 if import_names:
                     qname, asname = import_names
                     name = asname or qname
+                    if (
+                        qname in self._type_annotation_names
+                        or (asname and asname in self._type_annotation_names)
+                    ):
+                        return
 
             if _has_locals_call_after_node(stmt, node.scope()):
                 message_name = "possibly-unused-variable"
@@ -1826,16 +1831,16 @@ class VariablesChecker(BaseChecker):
             self._type_annotation_names.append(type_annotation.name)
             return
 
-        if not isinstance(type_annotation, astroid.Subscript):
+        if not isinstance(type_annotation, astroid.node_classes.NodeNG):
             return
 
         if (
-            isinstance(type_annotation.value, astroid.Attribute)
+            isinstance(type_annotation, astroid.Subscript)
+            and isinstance(type_annotation.value, astroid.Attribute)
             and isinstance(type_annotation.value.expr, astroid.Name)
             and type_annotation.value.expr.name == TYPING_MODULE
         ):
             self._type_annotation_names.append(TYPING_MODULE)
-            return
 
         self._type_annotation_names.extend(
             annotation.name

--- a/tests/functional/u/unused/unused_import_type_comments.py
+++ b/tests/functional/u/unused/unused_import_type_comments.py
@@ -1,0 +1,41 @@
+# pylint: disable=missing-docstring,import-outside-toplevel,reimported,redefined-outer-name
+
+import abc
+from abc import ABC
+import abc as module_abc
+from abc import ABC as ModuleAbc
+
+
+MODULE_TYPE_COMMENT = None  # type: abc.ABC
+MODULE_TYPE_NAME = None  # type: ABC
+MODULE_ALIAS_TYPE_COMMENT = None  # type: module_abc.ABC
+MODULE_ALIAS_TYPE_NAME = None  # type: ModuleAbc
+
+
+def module_values():
+    return (
+        MODULE_TYPE_COMMENT,
+        MODULE_TYPE_NAME,
+        MODULE_ALIAS_TYPE_COMMENT,
+        MODULE_ALIAS_TYPE_NAME,
+    )
+
+
+def function_type_comments():
+    import abc
+    from abc import ABC
+
+    func_module_comment = None  # type: abc.ABC
+    func_name_comment = None  # type: ABC
+
+    return func_module_comment, func_name_comment
+
+
+def function_alias_type_comments():
+    import abc as func_abc
+    from abc import ABC as FuncAbc
+
+    func_alias_module_comment = None  # type: func_abc.ABC
+    func_alias_name_comment = None  # type: FuncAbc
+
+    return func_alias_module_comment, func_alias_name_comment

--- a/tests/functional/u/unused/unused_import_type_comments.rc
+++ b/tests/functional/u/unused/unused_import_type_comments.rc
@@ -1,0 +1,3 @@
+[testoptions]
+min_pyver=3.6
+except_implementations=PyPy


### PR DESCRIPTION
## Summary
- ensure type annotation traversal collects `Name` nodes under attributes so type comments pick up module imports
- reuse collected annotation names when checking function-scope unused imports
- add functional coverage for module, function, and alias type-comment imports

## Testing
- pytest tests/functional/u/unused -k "type_comment"
- pytest tests/test_functional.py -k "type_comment"

## Reproduction
1. Save the reproduction snippet from #27 (imports only used in type comments) as `repro.py`.
2. Run `pylint repro.py` on pylint-dev__pylint-4604.
3. Observe `unused-import` diagnostics for imports such as `abc` and `ABC` used only in type comments inside functions.

After this change those imports are treated as used. Refs #27.