### PR TITLE
swev-id: pylint-dev__pylint-4661 - adopt XDG data directory for persistent data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,10 @@ Release date: TBA
 ..
   Put bug fixes that should not wait for a new minor version here
 
+* Pylint's persistent data now follows the XDG Base Directory specification by
+  default, using ``platformdirs`` with automatic migration from the legacy
+  ``~/.pylint.d`` directory.
+
 * Added ``unspecified-encoding``: Emitted when open() is called without specifying an encoding
 
   Closes #3826

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -91,12 +91,15 @@ or if "directory" is in the python path.
 Analysis data are stored as a pickle file in a directory which is
 localized using the following rules:
 
-* value of the PYLINTHOME environment variable if set
+* value of the PYLINTHOME environment variable if set.
 
-* ".pylint.d" subdirectory of the user's home directory if it is found
-	(not always findable on Windows platforms)
+* otherwise, the per-user data directory provided by the operating system
+  (via the XDG Base Directory specification implemented through
+  ``platformdirs``). When this new location is first used any existing data in
+  ``~/.pylint.d`` is migrated automatically.
 
-* ".pylint.d" directory in the current directory
+* if the user's home directory cannot be determined, a ``.pylint.d`` directory
+  is created in the current working directory (deprecated fallback).
 
 3.3 How do I find the option name (for pylintrc) corresponding to a specific command line option?
 --------------------------------------------------------------------------------------------------------

--- a/doc/whatsnew/2.10.rst
+++ b/doc/whatsnew/2.10.rst
@@ -21,6 +21,10 @@ Other Changes
 =============
 
 
+* Persistent data now defaults to the XDG Base Directory compliant location as
+  resolved by ``platformdirs``. Existing ``~/.pylint.d`` data is migrated
+  automatically on first use.
+
 * Performance of the Similarity checker has been improved.
 
 * Added ``time.clock`` to deprecated functions/methods for python 3.3

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -92,7 +92,13 @@ def _prepare_data_directory(target: Path, legacy: Path) -> Path:
             f"Pylint data path '{target}' exists but is not a directory. "
             f"Falling back to legacy location '{legacy}'."
         )
-        legacy.mkdir(parents=True, exist_ok=True)
+        try:
+            legacy.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            _warn(
+                f"Unable to create legacy Pylint data directory '{legacy}': {error}. "
+                "Persistent data will be disabled for this run."
+            )
         return legacy
 
     try:
@@ -102,7 +108,13 @@ def _prepare_data_directory(target: Path, legacy: Path) -> Path:
             f"Unable to create Pylint data directory '{target}': {error}. "
             f"Falling back to legacy location '{legacy}'."
         )
-        legacy.mkdir(parents=True, exist_ok=True)
+        try:
+            legacy.mkdir(parents=True, exist_ok=True)
+        except OSError as legacy_error:
+            _warn(
+                f"Unable to create legacy Pylint data directory '{legacy}': {legacy_error}. "
+                "Persistent data will be disabled for this run."
+            )
         return legacy
 
     if legacy.exists() and not sentinel.exists():
@@ -119,9 +131,20 @@ def _prepare_data_directory(target: Path, legacy: Path) -> Path:
                 f"Using legacy directory for this run."
             )
             shutil.rmtree(str(target), ignore_errors=True)
-            legacy.mkdir(parents=True, exist_ok=True)
+            try:
+                legacy.mkdir(parents=True, exist_ok=True)
+            except OSError as legacy_error:
+                _warn(
+                    f"Unable to create legacy Pylint data directory '{legacy}': {legacy_error}. "
+                    "Persistent data will be disabled for this run."
+                )
             return legacy
-        sentinel.touch(exist_ok=True)
+        try:
+            sentinel.touch(exist_ok=True)
+        except OSError as error:
+            _warn(
+                f"Unable to create migration sentinel '{sentinel}': {error}."
+            )
         _warn(
             f"Pylint persistent data migrated from '{legacy}' to '{target}'."
         )
@@ -137,7 +160,13 @@ def get_pylint_data_dir() -> str:
     home_path = _resolve_home()
     if home_path is None:
         fallback = Path(LEGACY_DATA_DIR_NAME)
-        fallback.mkdir(parents=True, exist_ok=True)
+        try:
+            fallback.mkdir(parents=True, exist_ok=True)
+        except OSError as error:
+            _warn(
+                f"Unable to create fallback Pylint data directory '{fallback}': {error}. "
+                "Persistent data will be disabled for this run."
+            )
         _warn(
             "HOME directory could not be resolved. Falling back to './.pylint.d'. "
             "This fallback is deprecated and will be removed in a future release.",

--- a/pylint/config/__init__.py
+++ b/pylint/config/__init__.py
@@ -34,7 +34,13 @@
 
 import os
 import pickle
+import shutil
 import sys
+import warnings
+from pathlib import Path
+from typing import Optional, Type
+
+from platformdirs import user_data_dir
 
 from pylint.config.configuration_mixin import ConfigurationMixIn
 from pylint.config.find_default_config_files import find_default_config_files
@@ -55,40 +61,127 @@ __all__ = [
     "UnsupportedAction",
 ]
 
+LEGACY_DATA_DIR_NAME = ".pylint.d"
+MIGRATION_SENTINEL = ".pylint-legacy-migrated"
+
+
+def _resolve_home() -> Optional[Path]:
+    expanded = Path(os.path.expanduser("~"))
+    if str(expanded) == "~":
+        return None
+    return expanded
+
+
+def _legacy_directory(home_path: Optional[Path]) -> Path:
+    if home_path is None:
+        return Path(LEGACY_DATA_DIR_NAME)
+    return home_path / LEGACY_DATA_DIR_NAME
+
+
+def _warn(message: str, category: Type[Warning] = UserWarning) -> None:
+    warnings.warn(message, category, stacklevel=3)
+
+
+def _prepare_data_directory(target: Path, legacy: Path) -> Path:
+    sentinel = target / MIGRATION_SENTINEL
+
+    if target.exists():
+        if target.is_dir():
+            return target
+        _warn(
+            f"Pylint data path '{target}' exists but is not a directory. "
+            f"Falling back to legacy location '{legacy}'."
+        )
+        legacy.mkdir(parents=True, exist_ok=True)
+        return legacy
+
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        _warn(
+            f"Unable to create Pylint data directory '{target}': {error}. "
+            f"Falling back to legacy location '{legacy}'."
+        )
+        legacy.mkdir(parents=True, exist_ok=True)
+        return legacy
+
+    if legacy.exists() and not sentinel.exists():
+        try:
+            for item in legacy.iterdir():
+                destination = target / item.name
+                if item.is_dir():
+                    shutil.copytree(str(item), str(destination))
+                else:
+                    shutil.copy2(str(item), str(destination))
+        except OSError as error:
+            _warn(
+                f"Unable to migrate data from '{legacy}' to '{target}': {error}. "
+                f"Using legacy directory for this run."
+            )
+            shutil.rmtree(str(target), ignore_errors=True)
+            legacy.mkdir(parents=True, exist_ok=True)
+            return legacy
+        sentinel.touch(exist_ok=True)
+        _warn(
+            f"Pylint persistent data migrated from '{legacy}' to '{target}'."
+        )
+
+    return target
+
+
+def get_pylint_data_dir() -> str:
+    override = os.environ.get("PYLINTHOME")
+    if override:
+        return override
+
+    home_path = _resolve_home()
+    if home_path is None:
+        fallback = Path(LEGACY_DATA_DIR_NAME)
+        fallback.mkdir(parents=True, exist_ok=True)
+        _warn(
+            "HOME directory could not be resolved. Falling back to './.pylint.d'. "
+            "This fallback is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+        )
+        return str(fallback)
+
+    data_directory = Path(user_data_dir(appname="pylint"))
+    legacy_directory = _legacy_directory(home_path)
+    resolved_directory = _prepare_data_directory(data_directory, legacy_directory)
+    return str(resolved_directory)
+
+
 USER_HOME = os.path.expanduser("~")
-if "PYLINTHOME" in os.environ:
-    PYLINT_HOME = os.environ["PYLINTHOME"]
-    if USER_HOME == "~":
-        USER_HOME = os.path.dirname(PYLINT_HOME)
-elif USER_HOME == "~":
-    PYLINT_HOME = ".pylint.d"
-else:
-    PYLINT_HOME = os.path.join(USER_HOME, ".pylint.d")
+PYLINT_HOME = get_pylint_data_dir()
+if "PYLINTHOME" in os.environ and USER_HOME == "~":
+    USER_HOME = os.path.dirname(PYLINT_HOME)
 
 
 def _get_pdata_path(base_name, recurs):
     base_name = base_name.replace(os.sep, "_")
-    return os.path.join(PYLINT_HOME, f"{base_name}{recurs}.stats")
+    return Path(PYLINT_HOME) / f"{base_name}{recurs}.stats"
 
 
 def load_results(base):
     data_file = _get_pdata_path(base, 1)
     try:
-        with open(data_file, "rb") as stream:
+        with data_file.open("rb") as stream:
             return pickle.load(stream)
     except Exception:  # pylint: disable=broad-except
         return {}
 
 
 def save_results(results, base):
-    if not os.path.exists(PYLINT_HOME):
-        try:
-            os.mkdir(PYLINT_HOME)
-        except OSError:
-            print("Unable to create directory %s" % PYLINT_HOME, file=sys.stderr)
+    data_directory = Path(PYLINT_HOME)
+    try:
+        data_directory.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        print(f"Unable to create directory {data_directory}: {error}", file=sys.stderr)
+        return
+
     data_file = _get_pdata_path(base, 1)
     try:
-        with open(data_file, "wb") as stream:
+        with data_file.open("wb") as stream:
             pickle.dump(results, stream)
     except OSError as ex:
         print(f"Unable to create file {data_file}: {ex}", file=sys.stderr)
@@ -110,8 +203,10 @@ ENV_HELP = (
 The following environment variables are used:
     * PYLINTHOME
     Path to the directory where persistent data for the run will be stored. If
-not found, it defaults to ~/.pylint.d/ or .pylint.d (in the current working
-directory).
+unset, Pylint uses the user data directory defined by the operating system via
+the XDG Base Directory specification. Data from the legacy ~/.pylint.d
+directory is migrated automatically. If the home directory cannot be
+determined, the fallback is ./.pylint.d (deprecated).
     * PYLINTRC
     Path to the configuration file. See the documentation for the method used
 to search for configuration file.

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     astroid>=2.6.5,<2.7 # (You should also upgrade requirements_test_min.txt)
     isort>=4.2.5,<6
     mccabe>=0.6,<0.7
+    platformdirs>=3.10,<5.0
     toml>=0.7.1
     colorama;sys_platform=="win32"
 python_requires = ~=3.6

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -39,13 +39,16 @@ import os
 import re
 import sys
 import tempfile
+import warnings
 from contextlib import contextmanager
 from importlib import reload
 from io import StringIO
+from pathlib import Path
 from os import chdir, getcwd
 from os.path import abspath, basename, dirname, isdir, join, sep
 from shutil import rmtree
 
+import platformdirs
 import pytest
 
 from pylint import checkers, config, exceptions, interfaces, lint, testutils
@@ -626,27 +629,136 @@ def pop_pylintrc():
 
 
 @pytest.mark.usefixtures("pop_pylintrc")
-def test_pylint_home():
-    uhome = os.path.expanduser("~")
-    if uhome == "~":
-        expected = ".pylint.d"
-    else:
-        expected = os.path.join(uhome, ".pylint.d")
-    assert config.PYLINT_HOME == expected
+def test_pylint_home_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "custom"
+    monkeypatch.setenv("PYLINTHOME", str(target))
+    reload(config)
+    try:
+        assert config.PYLINT_HOME == str(target)
+    finally:
+        monkeypatch.undo()
+        reload(config)
+
+
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_pylint_home_default_uses_platformdirs(monkeypatch, tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv(HOME, str(home_dir))
+    target_dir = tmp_path / "xdg" / "pylint"
+
+    def fake_user_data_dir(appname, *_args, **_kwargs):
+        assert appname == "pylint"
+        return str(target_dir)
+
+    monkeypatch.setattr(platformdirs, "user_data_dir", fake_user_data_dir)
+    reload(config)
+    try:
+        assert Path(config.PYLINT_HOME) == target_dir
+        assert target_dir.exists()
+    finally:
+        monkeypatch.undo()
+        reload(config)
+
+
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_pylint_home_migrates_legacy_directory(monkeypatch, tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv(HOME, str(home_dir))
+    legacy_dir = home_dir / ".pylint.d"
+    legacy_dir.mkdir()
+    legacy_file = legacy_dir / "cache.stats"
+    legacy_file.write_text("legacy", encoding="utf-8")
+    target_dir = tmp_path / "xdg" / "pylint"
+
+    def fake_user_data_dir(appname, *_args, **_kwargs):
+        assert appname == "pylint"
+        return str(target_dir)
+
+    monkeypatch.setattr(platformdirs, "user_data_dir", fake_user_data_dir)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        reload(config)
 
     try:
-        pylintd = join(tempfile.gettempdir(), ".pylint.d")
-        os.environ["PYLINTHOME"] = pylintd
-        try:
+        assert Path(config.PYLINT_HOME) == target_dir
+        copied_file = target_dir / legacy_file.name
+        assert copied_file.read_text(encoding="utf-8") == "legacy"
+        sentinel_path = target_dir / config.MIGRATION_SENTINEL
+        assert sentinel_path.is_file()
+        user_warnings = [
+            warning
+            for warning in caught
+            if issubclass(warning.category, UserWarning)
+        ]
+        assert any("migrated" in str(w.message) for w in user_warnings)
+
+        with warnings.catch_warnings(record=True) as second_caught:
+            warnings.simplefilter("always")
             reload(config)
-            assert config.PYLINT_HOME == pylintd
-        finally:
-            try:
-                os.remove(pylintd)
-            except FileNotFoundError:
-                pass
+        assert not any(
+            "migrated" in str(w.message)
+            for w in second_caught
+            if issubclass(w.category, UserWarning)
+        )
     finally:
-        del os.environ["PYLINTHOME"]
+        monkeypatch.undo()
+        reload(config)
+
+
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_pylint_home_migration_falls_back_on_error(monkeypatch, tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv(HOME, str(home_dir))
+    legacy_dir = home_dir / ".pylint.d"
+    legacy_dir.mkdir()
+    blocked_path = tmp_path / "xdg" / "pylint"
+    blocked_path.parent.mkdir(parents=True, exist_ok=True)
+    blocked_path.touch()
+
+    def fake_user_data_dir(appname, *_args, **_kwargs):
+        assert appname == "pylint"
+        return str(blocked_path)
+
+    monkeypatch.setattr(platformdirs, "user_data_dir", fake_user_data_dir)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        reload(config)
+
+    try:
+        assert Path(config.PYLINT_HOME) == legacy_dir
+        messages = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, UserWarning)
+        ]
+        assert any("Falling back to legacy" in message for message in messages)
+    finally:
+        monkeypatch.undo()
+        reload(config)
+
+
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_pylint_home_fallback_when_home_unknown(monkeypatch):
+    monkeypatch.setattr(os.path, "expanduser", lambda _: "~")
+    try:
+        with tempdir():
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                reload(config)
+
+            assert config.PYLINT_HOME == config.LEGACY_DATA_DIR_NAME
+            assert Path(config.PYLINT_HOME).exists()
+            assert any(
+                issubclass(w.category, DeprecationWarning) for w in caught
+            )
+    finally:
+        monkeypatch.undo()
+        reload(config)
 
 
 @pytest.mark.usefixtures("pop_pylintrc")

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -637,6 +637,8 @@ def test_pylint_home_env_override(monkeypatch, tmp_path):
         assert config.PYLINT_HOME == str(target)
     finally:
         monkeypatch.undo()
+        monkeypatch.undo()
+        monkeypatch.undo()
         reload(config)
 
 
@@ -737,6 +739,47 @@ def test_pylint_home_migration_falls_back_on_error(monkeypatch, tmp_path):
             if issubclass(w.category, UserWarning)
         ]
         assert any("Falling back to legacy" in message for message in messages)
+    finally:
+        monkeypatch.undo()
+        reload(config)
+
+
+@pytest.mark.usefixtures("pop_pylintrc")
+def test_pylint_home_warns_when_directories_unwritable(monkeypatch, tmp_path):
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv(HOME, str(home_dir))
+    target_dir = tmp_path / "xdg" / "pylint"
+    legacy_dir = home_dir / ".pylint.d"
+
+    def fake_user_data_dir(appname, *_args, **_kwargs):
+        assert appname == "pylint"
+        return str(target_dir)
+
+    monkeypatch.setattr(platformdirs, "user_data_dir", fake_user_data_dir)
+
+    original_mkdir = Path.mkdir
+
+    def failing_mkdir(self, *args, **kwargs):
+        if str(self) in {str(target_dir), str(legacy_dir)}:
+            raise OSError("permission denied")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", failing_mkdir)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        reload(config)
+
+    try:
+        assert config.PYLINT_HOME == str(legacy_dir)
+        warning_messages = [
+            str(w.message)
+            for w in caught
+            if issubclass(w.category, UserWarning)
+        ]
+        assert any("Unable to create Pylint data directory" in msg for msg in warning_messages)
+        assert any("Unable to create legacy Pylint data directory" in msg for msg in warning_messages)
     finally:
         monkeypatch.undo()
         reload(config)


### PR DESCRIPTION
## Summary
- add a platformdirs-based resolver for pylint\'s persistent data with legacy migration, sentinel, and warnings
- add the runtime dependency and refresh ENV_HELP, FAQ, and whatsnew documentation
- expand lint tests to cover env precedence, migration success/failure, and home fallback scenarios

Closes #23

## Testing
- PYTHONPATH=/workspace/pylint .venv/bin/pytest *(fails: tests/test_functional.py::test_functional[regression_4439] expected unsupported-assignment-operation, tests/test_functional.py::test_functional[recursion_error_3152] unexpected abstract-method — both pre-existing)*
- PYTHONPATH=/workspace/pylint .venv/bin/pytest tests/lint/unittest_lint.py::test_pylint_home_env_override tests/lint/unittest_lint.py::test_pylint_home_default_uses_platformdirs tests/lint/unittest_lint.py::test_pylint_home_migrates_legacy_directory tests/lint/unittest_lint.py::test_pylint_home_migration_falls_back_on_error tests/lint/unittest_lint.py::test_pylint_home_fallback_when_home_unknown
- PYTHONPATH=/workspace/pylint .venv/bin/python -m pylint pylint/config/__init__.py tests/lint/unittest_lint.py