### PR TITLE
swev-id: pylint-dev__pylint-6903 Clamp auto jobs to >=1 to avoid Pool(processes=0) under cgroups (K8s)

### DIFF
--- a/pylint/lint/run.py
+++ b/pylint/lint/run.py
@@ -76,8 +76,8 @@ def _cpu_count() -> int:
     else:
         cpu_count = 1
     if cpu_share is not None:
-        return min(cpu_share, cpu_count)
-    return cpu_count
+        return max(1, min(cpu_share, cpu_count))
+    return max(1, cpu_count)
 
 
 UNUSED_PARAM_SENTINEL = object()

--- a/tests/test_cpu_count_minimum.py
+++ b/tests/test_cpu_count_minimum.py
@@ -1,0 +1,21 @@
+import os
+from pylint.lint import run as run_mod
+
+
+def test_cpu_count_clamped_to_minimum(monkeypatch):
+    """_cpu_count should never return 0 even if _query_cpu reports 0.
+
+    This covers cases where cgroup-derived estimates truncate to 0 (e.g.,
+    cpu.shares < 1024 or quota < period). The clamping in _cpu_count should
+    force a minimum of 1.
+    """
+    # Force _query_cpu to report 0
+    monkeypatch.setattr(run_mod, "_query_cpu", lambda: 0)
+
+    # Ensure a sane cpu_count path; regardless of affinity/multiprocessing,
+    # the function should clamp to at least 1.
+    if hasattr(os, "sched_getaffinity"):
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1})
+
+    result = run_mod._cpu_count()
+    assert result >= 1


### PR DESCRIPTION
## Summary
Ensure the auto-detected jobs count from cgroup estimates is never below 1, preventing `multiprocessing.Pool(processes=0)` crashes when running `pylint --jobs=0`.

- Minimal change in `pylint/lint/run.py` `_cpu_count()` to clamp computed value to at least 1.
- Preserves existing logic for cgroups v1/v2 and non-cgroup platforms.

Linked Issue: https://github.com/agyn-sandbox/pylint/issues/32

## Background
In certain Kubernetes/cgroups v1 environments, the newly introduced `_query_cpu()` may yield `0` due to integer truncation:
- `/sys/fs/cgroup/cpu/cpu.cfs_quota_us = -1`
- `/sys/fs/cgroup/cpu/cpu.cfs_period_us = 100000`
- `/sys/fs/cgroup/cpu/cpu.shares = 2` -> `int(2/1024) == 0`

With `--jobs=0`, `_cpu_count()` can then return `0`, leading to:
```text
ValueError: Number of processes must be at least 1
  File "/usr/local/lib/python3.9/dist-packages/pylint/lint/run.py", line 197, in __init__
    linter.check(args)
  File "/usr/local/lib/python3.9/dist-packages/pylint/lint/pylinter.py", line 650, in check
    check_parallel(
  File "/usr/local/lib/python3.9/dist-packages/pylint/lint/parallel.py", line 140, in check_parallel
    with multiprocessing.Pool(
  File "/usr/lib/python3.9/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
  File "/usr/lib/python3.9/multiprocessing/pool.py", line 205, in __init__
    raise ValueError("Number of processes must be at least 1")
```

## Change
In `_cpu_count()`:
- If `cpu_share` is not `None`, return `max(1, min(cpu_share, cpu_count))`.
- Else, return `max(1, cpu_count)`.

This ensures `--jobs=0` never results in `0` workers, and single-process execution is used when cgroup-derived CPU allocation is below 1.

## Reproduction steps (pre-fix)
1) K8s/cgroups v1 environment with values above; run:
```bash
pylint --jobs=0 --verbose my_package
```
Expected: `ValueError: Number of processes must be at least 1` (see stack above).

2) Local monkeypatch:
- Patch `pathlib.Path.is_file` and `open()` to return the values above for cgroups v1 files.
- Run `pylint --jobs=0` on a minimal input.
Expected (pre-fix): same `ValueError`.

## Expected behavior (post-fix)
- `--jobs=0` clamps to `>=1`. When cgroup estimate < 1, jobs == 1; otherwise jobs == min(cgroup_estimate, cpu_count).

## Notes
- We are not running CI per request; unit tests suggested in the Issue for future validation.
- Prior art mentioned by maintainers: pylint PR #6098 and Python bpo-36054.