### PR TITLE
Respect ignore options in recursive mode (swev-id: pylint-dev__pylint-6528)

### DIFF
--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -42,16 +42,25 @@ def get_python_path(filepath: str) -> str:
 
 
 def _ignore_path_candidates(element: str) -> tuple[str, ...]:
-    candidates: list[str] = [element]
-    if element.startswith("."):
-        forward = element.replace("\\", "/")
-        backward = element.replace("/", "\\")
-        candidates.append("/" + forward)
-        candidates.append("\\" + backward)
-    # Preserve order while removing duplicates.
+    normalized = _normalized_path_for_ignore(element)
+    posix_normalized = normalized.replace("\\", "/")
+    windows_normalized = normalized.replace("/", "\\")
+    candidates: list[str] = [element, normalized]
+    if posix_normalized:
+        candidates.append(f"./{posix_normalized}")
+    if windows_normalized:
+        candidates.append(f".\\{windows_normalized}")
+    if posix_normalized.startswith("."):
+        candidates.append(f"/{posix_normalized}")
+    if windows_normalized.startswith("."):
+        candidates.append(f"\\{windows_normalized}")
+    candidates.extend((posix_normalized, windows_normalized))
+
     seen: set[str] = set()
     unique_candidates: list[str] = []
     for candidate in candidates:
+        if not candidate:
+            continue
         if candidate in seen:
             continue
         seen.add(candidate)

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -586,13 +586,15 @@ class PyLinter(
         for argument in files_or_modules:
             normalized_argument = os.path.normpath(argument)
             basename_argument = os.path.basename(normalized_argument)
+            is_directory = os.path.isdir(argument)
 
-            if is_ignored_basename(basename_argument) or is_ignored_path(
-                normalized_argument
+            if is_directory and (
+                is_ignored_basename(basename_argument)
+                or is_ignored_path(normalized_argument)
             ):
                 continue
 
-            if not os.path.isdir(argument):
+            if not is_directory:
                 yield normalized_argument
                 continue
 
@@ -604,7 +606,9 @@ class PyLinter(
                 normalized_root = os.path.normpath(root)
                 basename_root = os.path.basename(normalized_root)
 
-                if is_ignored_basename(basename_root) or is_ignored_path(root):
+                if is_ignored_basename(basename_root) or is_ignored_path(
+                    normalized_root
+                ):
                     dirs[:] = []
                     continue
 

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -576,20 +576,21 @@ class PyLinter(
             ):
                 skip_subtrees: list[str] = []
                 for root, _, files in os.walk(something):
-                    if any(root.startswith(s) for s in skip_subtrees):
+                    normalized_root = os.path.normpath(root)
+                    if any(normalized_root.startswith(s) for s in skip_subtrees):
                         # Skip subtree of already discovered package.
                         continue
                     if "__init__.py" in files:
-                        skip_subtrees.append(root)
-                        yield root
+                        skip_subtrees.append(normalized_root)
+                        yield normalized_root
                     else:
                         yield from (
-                            os.path.join(root, file)
+                            os.path.normpath(os.path.join(root, file))
                             for file in files
                             if file.endswith(".py")
                         )
             else:
-                yield something
+                yield os.path.normpath(something)
 
     def check(self, files_or_modules: Sequence[str] | str) -> None:
         """Main checking entry: check a list of files or modules from their name.

--- a/tests/lint/test_recursive_ignore.py
+++ b/tests/lint/test_recursive_ignore.py
@@ -1,0 +1,125 @@
+"""Tests ensuring recursive discovery respects ignore options."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+from pylint.lint.pylinter import PyLinter
+from pylint.testutils import GenericTestReporter
+
+
+def _write_module(path: Path) -> None:
+    path.write_text("import os\n", encoding="utf-8")
+
+
+def _build_sample_tree(root: Path) -> None:
+    (root / "a").mkdir()
+    _write_module(root / "a" / "foo.py")
+
+    (root / ".hidden").mkdir()
+    _write_module(root / ".hidden" / "bar.py")
+
+    (root / "pkg").mkdir()
+    _write_module(root / "pkg" / "__init__.py")
+    _write_module(root / "pkg" / "mod.py")
+
+    (root / "pkg" / ".hiddenpkg").mkdir()
+    _write_module(root / "pkg" / ".hiddenpkg" / "baz.py")
+
+    (root / ".a").mkdir()
+    _write_module(root / ".a" / "foo.py")
+
+    _write_module(root / "single.py")
+
+
+def _run_linter(linter: PyLinter, targets: Iterable[str | Path]) -> set[Path]:
+    linter.set_reporter(GenericTestReporter())
+    linter.check([str(target) for target in targets])
+    return {
+        Path(message.path)
+        for message in linter.reporter.messages
+    }
+
+
+def _relative_paths(messages: set[Path], base: Path) -> set[Path]:
+    return {path.relative_to(base) for path in messages}
+
+
+@pytest.fixture()
+def sample_tree(tmp_path: Path) -> Path:
+    _build_sample_tree(tmp_path)
+    return tmp_path
+
+
+def test_recursive_ignore_patterns_skip_hidden_directories(
+    linter: PyLinter, sample_tree: Path
+) -> None:
+    linter.config.recursive = True
+    linter.config.ignore_patterns = tuple(
+        list(linter.config.ignore_patterns) + [re.compile(r"^\.")]
+    )
+
+    linted = _relative_paths(_run_linter(linter, [sample_tree]), sample_tree)
+
+    assert Path("single.py") in linted
+    assert Path("pkg/__init__.py") in linted
+    assert Path("pkg/mod.py") in linted
+    assert Path("a/foo.py") in linted
+
+    assert Path(".hidden/bar.py") not in linted
+    assert Path("pkg/.hiddenpkg/baz.py") not in linted
+    assert Path(".a/foo.py") not in linted
+
+
+def test_recursive_ignore_option_skips_directory(
+    linter: PyLinter, sample_tree: Path
+) -> None:
+    linter.config.recursive = True
+    linter.config.ignore = tuple(list(linter.config.ignore) + [".a"])
+
+    linted = _relative_paths(_run_linter(linter, [sample_tree]), sample_tree)
+
+    assert Path(".a/foo.py") not in linted
+    assert Path("a/foo.py") in linted
+
+
+def test_recursive_ignore_paths_skip_pattern(
+    linter: PyLinter, sample_tree: Path
+) -> None:
+    linter.config.recursive = True
+    linter.config.ignore_paths = [re.compile(r".*/\.a(/|\\).*")]
+
+    linted = _relative_paths(_run_linter(linter, [sample_tree]), sample_tree)
+
+    assert Path(".a/foo.py") not in linted
+    assert Path("a/foo.py") in linted
+
+
+def test_recursive_ignore_patterns_on_filename(
+    linter: PyLinter, sample_tree: Path
+) -> None:
+    linter.config.recursive = True
+    linter.config.ignore_patterns = tuple(
+        list(linter.config.ignore_patterns) + [re.compile(r"^foo\.py$")]
+    )
+
+    linted = _relative_paths(_run_linter(linter, [sample_tree]), sample_tree)
+
+    assert Path("a/foo.py") not in linted
+    assert Path(".a/foo.py") not in linted
+    assert Path("pkg/mod.py") in linted
+    assert Path("single.py") in linted
+
+
+def test_non_recursive_single_file_unchanged(
+    linter: PyLinter, sample_tree: Path
+) -> None:
+    linter.config.recursive = False
+
+    linted = _run_linter(linter, [sample_tree / "single.py"])
+
+    assert Path(sample_tree / "single.py") in linted

--- a/tests/lint/test_recursive_ignore.py
+++ b/tests/lint/test_recursive_ignore.py
@@ -1,13 +1,15 @@
 """Tests ensuring recursive discovery respects ignore options."""
 
+# pylint: disable=redefined-outer-name
+
 from __future__ import annotations
 
-import re
 from pathlib import Path
 
 import pytest
 
-from pylint.lint.pylinter import PyLinter
+from pylint.lint import Run
+from pylint.testutils import GenericTestReporter
 
 
 def _write_module(path: Path) -> None:
@@ -34,13 +36,32 @@ def _build_sample_tree(root: Path) -> None:
     _write_module(root / "single.py")
 
 
-def _recursive_discovered_paths(
-    linter: PyLinter, base: Path, targets: list[Path]
+def _linted_paths(
+    base: Path,
+    targets: list[Path],
+    *,
+    recursive: bool,
+    extra_args: list[str] | None = None,
 ) -> set[Path]:
-    linter.open()
+    reporter = GenericTestReporter()
+    args = [
+        "--rcfile=/dev/null",
+        "--disable=all",
+        "--enable=missing-module-docstring",
+        "--persistent=n",
+        "--score=n",
+        "--reports=n",
+        "--jobs=1",
+        "--recursive=y" if recursive else "--recursive=n",
+    ]
+    if extra_args:
+        args.extend(extra_args)
+    args.extend(str(target) for target in targets)
+    Run(args, reporter=reporter, exit=False)
     return {
-        Path(path).resolve().relative_to(base)
-        for path in linter._discover_files([str(target) for target in targets])
+        Path(message.abspath).resolve().relative_to(base)
+        for message in reporter.messages
+        if message.symbol == "missing-module-docstring"
     }
 
 
@@ -50,18 +71,17 @@ def sample_tree(tmp_path: Path) -> Path:
     return tmp_path
 
 
-def test_recursive_ignore_patterns_skip_hidden_directories(
-    linter: PyLinter, sample_tree: Path
-) -> None:
-    linter.config.recursive = True
-    linter.config.ignore_patterns = tuple(
-        list(linter.config.ignore_patterns) + [re.compile(r"^\.")]
+def test_recursive_ignore_patterns_skip_hidden_directories(sample_tree: Path) -> None:
+    linted = _linted_paths(
+        sample_tree,
+        [sample_tree],
+        recursive=True,
+        extra_args=["--ignore-patterns=^\\.\\w"],
     )
 
-    linted = _recursive_discovered_paths(linter, sample_tree, [sample_tree])
-
     assert Path("single.py") in linted
-    assert Path("pkg") in linted
+    assert Path("pkg/__init__.py") in linted
+    assert Path("pkg/mod.py") in linted
     assert Path("a/foo.py") in linted
 
     assert Path(".hidden/bar.py") not in linted
@@ -69,58 +89,53 @@ def test_recursive_ignore_patterns_skip_hidden_directories(
     assert Path(".a/foo.py") not in linted
 
 
-def test_recursive_ignore_option_skips_directory(
-    linter: PyLinter, sample_tree: Path
-) -> None:
-    linter.config.recursive = True
-    linter.config.ignore = tuple(list(linter.config.ignore) + [".a"])
-
-    linted = _recursive_discovered_paths(linter, sample_tree, [sample_tree])
+def test_recursive_ignore_option_skips_directory(sample_tree: Path) -> None:
+    linted = _linted_paths(
+        sample_tree,
+        [sample_tree],
+        recursive=True,
+        extra_args=["--ignore=.a"],
+    )
 
     assert Path(".a/foo.py") not in linted
     assert Path("a/foo.py") in linted
     assert Path("single.py") in linted
 
 
-def test_recursive_ignore_paths_skip_pattern(
-    linter: PyLinter, sample_tree: Path
-) -> None:
-    linter.config.recursive = True
-    linter.config.ignore_paths = tuple(
-        list(linter.config.ignore_paths)
-        + [re.compile(r".*/\.a(?:/|\\|$).*")]
+def test_recursive_ignore_paths_skip_pattern(sample_tree: Path) -> None:
+    linted = _linted_paths(
+        sample_tree,
+        [sample_tree],
+        recursive=True,
+        extra_args=["--ignore-paths=.*/\\.a(?:/|\\\\|$).*"],
     )
-
-    linted = _recursive_discovered_paths(linter, sample_tree, [sample_tree])
 
     assert Path(".a/foo.py") not in linted
     assert Path("a/foo.py") in linted
-    assert Path("pkg") in linted
+    assert Path("pkg/__init__.py") in linted
+    assert Path("pkg/mod.py") in linted
 
 
-def test_recursive_ignore_patterns_on_filename(
-    linter: PyLinter, sample_tree: Path
-) -> None:
-    linter.config.recursive = True
-    linter.config.ignore_patterns = tuple(
-        list(linter.config.ignore_patterns) + [re.compile(r"^foo\.py$")]
+def test_recursive_ignore_patterns_on_filename(sample_tree: Path) -> None:
+    linted = _linted_paths(
+        sample_tree,
+        [sample_tree],
+        recursive=True,
+        extra_args=["--ignore-patterns=^foo\\.py$"],
     )
-
-    linted = _recursive_discovered_paths(linter, sample_tree, [sample_tree])
 
     assert Path("a/foo.py") not in linted
     assert Path(".a/foo.py") not in linted
-    assert Path("pkg") in linted
+    assert Path("pkg/__init__.py") in linted
+    assert Path("pkg/mod.py") in linted
     assert Path("single.py") in linted
 
 
-def test_non_recursive_single_file_unchanged(
-    linter: PyLinter, sample_tree: Path
-) -> None:
-    linter.config.recursive = False
+def test_non_recursive_single_file_unchanged(sample_tree: Path) -> None:
+    linted = _linted_paths(
+        sample_tree,
+        [sample_tree / "single.py"],
+        recursive=False,
+    )
 
-    linter.open()
-    module_descriptions = linter._expand_files([str(sample_tree / "single.py")])
-    linted = {Path(description["path"]) for description in module_descriptions}
-
-    assert Path(sample_tree / "single.py") in linted
+    assert Path("single.py") in linted

--- a/tests/lint/test_recursive_ignore.py
+++ b/tests/lint/test_recursive_ignore.py
@@ -43,9 +43,11 @@ def _linted_paths(
     recursive: bool,
     extra_args: list[str] | None = None,
 ) -> set[Path]:
+    rcfile = base / "pylintrc"
+    rcfile.write_text("[MASTER]\n", encoding="utf-8")
     reporter = GenericTestReporter()
     args = [
-        "--rcfile=/dev/null",
+        f"--rcfile={rcfile}",
         "--disable=all",
         "--enable=missing-module-docstring",
         "--persistent=n",

--- a/tests/lint/test_recursive_ignore_paths.py
+++ b/tests/lint/test_recursive_ignore_paths.py
@@ -1,0 +1,54 @@
+# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+# For details: https://github.com/PyCQA/pylint/blob/main/LICENSE
+# Copyright (c) https://github.com/PyCQA/pylint/blob/main/CONTRIBUTORS.txt
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pylint.lint.expand_modules import expand_modules
+from pylint.lint.pylinter import PyLinter
+
+
+def test_ignore_hidden_dir_with_recursive(tmp_path, linter, monkeypatch):
+    hidden_dir = tmp_path / ".a"
+    hidden_dir.mkdir()
+    (hidden_dir / "foo.py").write_text("print('foo')\n", encoding="utf8")
+    (tmp_path / "bar.py").write_text("print('bar')\n", encoding="utf8")
+
+    monkeypatch.chdir(tmp_path)
+    linter.global_set_option("ignore-paths", r"^\.a")
+
+    discovered = tuple(PyLinter._discover_files(["."]))
+    modules, errors = expand_modules(
+        discovered,
+        list(linter.config.ignore),
+        list(linter.config.ignore_patterns),
+        linter.config.ignore_paths,
+    )
+
+    assert not errors
+    paths = {Path(module["path"]) for module in modules}
+    assert any(path.name == "bar.py" for path in paths)
+    assert all(path.name != "foo.py" for path in paths)
+
+
+def test_ignore_paths_normalization_removes_leading_dot_slash(
+    tmp_path, linter, monkeypatch
+):
+    hidden_dir = tmp_path / ".a"
+    hidden_dir.mkdir()
+    (hidden_dir / "foo.py").write_text("print('foo')\n", encoding="utf8")
+
+    monkeypatch.chdir(tmp_path)
+    linter.global_set_option("ignore-paths", r"^\.a")
+
+    modules, errors = expand_modules(
+        ["./.a/foo.py"],
+        list(linter.config.ignore),
+        list(linter.config.ignore_patterns),
+        linter.config.ignore_paths,
+    )
+
+    assert not errors
+    assert modules == []

--- a/tests/lint/test_recursive_ignore_paths.py
+++ b/tests/lint/test_recursive_ignore_paths.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from pylint.lint.expand_modules import expand_modules
-from pylint.lint.pylinter import PyLinter
 
 
 def test_ignore_hidden_dir_with_recursive(tmp_path, linter, monkeypatch):
@@ -19,7 +18,7 @@ def test_ignore_hidden_dir_with_recursive(tmp_path, linter, monkeypatch):
     monkeypatch.chdir(tmp_path)
     linter.global_set_option("ignore-paths", r"^\.a")
 
-    discovered = tuple(PyLinter._discover_files(["."]))
+    discovered = tuple(linter._discover_files(["."]))
     modules, errors = expand_modules(
         discovered,
         list(linter.config.ignore),
@@ -51,7 +50,7 @@ def test_ignore_paths_normalization_removes_leading_dot_slash(
     )
 
     assert not errors
-    assert modules == []
+    assert not modules
 
 
 def test_ignore_paths_supports_prefixed_dot_slash(tmp_path, linter, monkeypatch):
@@ -63,7 +62,7 @@ def test_ignore_paths_supports_prefixed_dot_slash(tmp_path, linter, monkeypatch)
     monkeypatch.chdir(tmp_path)
     linter.global_set_option("ignore-paths", r"^\./\.a")
 
-    discovered = tuple(PyLinter._discover_files(["."]))
+    discovered = tuple(linter._discover_files(["."]))
     modules, errors = expand_modules(
         discovered,
         list(linter.config.ignore),

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -69,6 +69,14 @@ test_pylinter = {
     "path": str(TEST_DIRECTORY / "lint/test_pylinter.py"),
 }
 
+test_recursive_ignore_paths = {
+    "basename": "lint",
+    "basepath": INIT_PATH,
+    "isarg": False,
+    "name": "lint.test_recursive_ignore_paths",
+    "path": str(TEST_DIRECTORY / "lint/test_recursive_ignore_paths.py"),
+}
+
 test_caching = {
     "basename": "lint",
     "basepath": INIT_PATH,
@@ -109,6 +117,7 @@ class TestExpandModules(CheckerTestCase):
                     init_of_package,
                     test_caching,
                     test_pylinter,
+                    test_recursive_ignore_paths,
                     test_utils,
                     this_file_from_init,
                     unittest_lint,


### PR DESCRIPTION
## Summary
- ensure recursive discovery skips ignored basenames and normalized paths
- update recursive ignore tests to validate discovered modules directly
- cover ignore path patterns and preserve non-recursive behavior

## Testing
- pytest tests/lint/test_recursive_ignore.py
- pytest tests/test_self.py::TestRunTC::test_recursive
- pytest tests/test_self.py::TestRunTC::test_recursive_current_dir

Fixes #24