### PR TITLE
swev-id: pylint-dev__pylint-7080 Fix: normalize paths before applying ignore-paths in recursive discovery

### DIFF
--- a/pylint/lint/expand_modules.py
+++ b/pylint/lint/expand_modules.py
@@ -53,10 +53,11 @@ def _is_ignored_file(
     ignore_list_paths_re: list[Pattern[str]],
 ) -> bool:
     basename = os.path.basename(element)
+    normalized_element = os.path.normpath(element)
     return (
         basename in ignore_list
         or _is_in_ignore_list_re(basename, ignore_list_re)
-        or _is_in_ignore_list_re(element, ignore_list_paths_re)
+        or _is_in_ignore_list_re(normalized_element, ignore_list_paths_re)
     )
 
 
@@ -140,9 +141,12 @@ def expand_modules(
             ):
                 if filepath == subfilepath:
                     continue
+                normalized_subfilepath = os.path.normpath(subfilepath)
                 if _is_in_ignore_list_re(
                     os.path.basename(subfilepath), ignore_list_re
-                ) or _is_in_ignore_list_re(subfilepath, ignore_list_paths_re):
+                ) or _is_in_ignore_list_re(
+                    normalized_subfilepath, ignore_list_paths_re
+                ):
                     continue
 
                 modpath = _modpath_from_file(

--- a/tests/lint/unittest_expand_modules.py
+++ b/tests/lint/unittest_expand_modules.py
@@ -4,14 +4,21 @@
 
 from __future__ import annotations
 
+import ntpath
 import re
 from pathlib import Path
 
 import pytest
 
+import pylint.lint.expand_modules as expand_modules_module
 from pylint.checkers import BaseChecker
-from pylint.lint.expand_modules import _is_in_ignore_list_re, expand_modules
-from pylint.testutils import CheckerTestCase, set_config
+from pylint.lint.expand_modules import (
+    _is_ignored_file,
+    _is_in_ignore_list_re,
+    expand_modules,
+)
+from pylint.testutils import CheckerTestCase, create_files, set_config
+from pylint.testutils._run import _Run as Run
 from pylint.typing import MessageDefinitionTuple
 
 
@@ -24,6 +31,80 @@ def test__is_in_ignore_list_re_match() -> None:
     assert _is_in_ignore_list_re("unittest_utils.py", patterns)
     assert _is_in_ignore_list_re("cheese_enchiladas.xml", patterns)
     assert _is_in_ignore_list_re("src/tests/whatever.xml", patterns)
+
+
+def test__is_ignored_file_normalizes_relative_paths() -> None:
+    ignore_paths_patterns = [re.compile(r"^src/gen/.*$")]
+    assert _is_ignored_file("./src/gen/module.py", [], [], ignore_paths_patterns)
+    assert _is_ignored_file("src/gen/module.py", [], [], ignore_paths_patterns)
+    assert not _is_ignored_file("./src/app/module.py", [], [], ignore_paths_patterns)
+
+
+def test__is_ignored_file_normalizes_windows_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    ignore_paths_patterns = [re.compile(r"^src\\gen\\.*$")]
+    monkeypatch.setattr(
+        expand_modules_module.os.path, "normpath", ntpath.normpath, raising=False
+    )
+    assert _is_ignored_file(".\\src\\gen\\module.py", [], [], ignore_paths_patterns)
+    assert _is_ignored_file("src\\gen\\module.py", [], [], ignore_paths_patterns)
+    assert not _is_ignored_file(
+        ".\\src\\app\\module.py", [], [], ignore_paths_patterns
+    )
+
+
+@pytest.mark.parametrize("target", ("src/", "."))
+@pytest.mark.parametrize("ignore_pattern", (r"^src/gen/.*$", r"^src\\\\gen\\\\.*$"))
+def test_expand_modules_respects_ignore_paths_on_recursive_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: str, ignore_pattern: str
+) -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    monkeypatch.syspath_prepend(str(project_root))
+    create_files(
+        [
+            "src/__init__.py",
+            "src/app/__init__.py",
+            "src/app/ok.py",
+            "src/gen/__init__.py",
+            "src/gen/failing.py",
+        ],
+        chroot=str(tmp_path),
+    )
+    (tmp_path / "src" / "app" / "ok.py").write_text(
+        "def ok():\n    return 1\n", encoding="utf-8"
+    )
+    (tmp_path / "src" / "gen" / "failing.py").write_text(
+        "def broken():\n    return unknown\n", encoding="utf-8"
+    )
+
+    monkeypatch.chdir(tmp_path)
+    run = Run(
+        [
+            "--recursive=y",
+            "--disable=all",
+            f"--ignore-paths={ignore_pattern}",
+            target,
+        ],
+        exit=False,
+    )
+
+    descriptors = run.linter._iterate_file_descrs(
+        tuple(run.linter._discover_files([target]))
+    )
+    base = tmp_path.resolve()
+
+    def to_relative(path_str: str) -> str:
+        candidate = Path(path_str)
+        if not candidate.is_absolute():
+            candidate = (base / candidate).resolve()
+        else:
+            candidate = candidate.resolve()
+        return candidate.relative_to(base).as_posix()
+
+    linted_paths = {to_relative(descriptor.filepath) for descriptor in descriptors}
+
+    assert "src/gen/failing.py" not in linted_paths
+    assert "src/gen/__init__.py" not in linted_paths
+    assert "src/app/ok.py" in linted_paths
 
 
 TEST_DIRECTORY = Path(__file__).parent.parent


### PR DESCRIPTION
## Issue
Fixes #34.

## Reproduction
1. Create src/app and src/gen packages with lintable files.
2. Configure \`[tool.pylint.MASTER]\` `ignore-paths = [\"^src/gen/.*$\"]`.
3. Run \`pylint --recursive=y src/\` and \`pylint --recursive=y .\`.

## Observed
- The \`src/gen\` files are ignored when targeting \`src/\` but not when targeting \`.\`.

## Fix
- Normalize filesystem paths before evaluating regex-based ignore-path patterns.
- Extend unit coverage for `_is_ignored_file` to ensure relative and Windows-style paths are handled.
- Add recursive discovery integration tests covering both `src/` and `.` entry points for forward- and backslash patterns.

## Testing
- .venv/bin/pytest tests/lint/unittest_expand_modules.py