### PR TITLE
fix: guard regex csv parsing (swev-id: pylint-dev__pylint-8898)

### DIFF
--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -118,21 +118,24 @@ class _CharClassTracker:
         self.active = False
         self.position = 0
         self.first_char: str | None = None
+        self.first_char_escaped = False
 
     def try_enter(self, char: str, buffer: list[str]) -> bool:
         if char == "[" and not self.active:
             self.active = True
             self.position = 0
             self.first_char = None
+            self.first_char_escaped = False
             buffer.append(char)
             return True
         return False
 
-    def record_literal(self, char: str) -> None:
+    def record_literal(self, char: str, *, escaped: bool) -> None:
         if not self.active:
             return
         if self.position == 0:
             self.first_char = char
+            self.first_char_escaped = escaped
         self.position += 1
 
     def consume(self, char: str, buffer: list[str]) -> bool:
@@ -140,18 +143,21 @@ class _CharClassTracker:
             return False
         if char == "]":
             if self.position == 0 or (
-                self.position == 1 and self.first_char == "^"
+                self.position == 1
+                and self.first_char == "^"
+                and not self.first_char_escaped
             ):
                 buffer.append(char)
-                self.record_literal(char)
+                self.record_literal(char, escaped=False)
                 return True
             buffer.append(char)
             self.active = False
             self.position = 0
             self.first_char = None
+            self.first_char_escaped = False
             return True
         buffer.append(char)
-        self.record_literal(char)
+        self.record_literal(char, escaped=False)
         return True
 
     def ensure_closed(self, value: str) -> None:
@@ -175,7 +181,7 @@ def _split_regex_csv(value: str) -> Sequence[str]:
             buffer.append(char)
             escaped = False
             if char_class.active:
-                char_class.record_literal(char)
+                char_class.record_literal(char, escaped=True)
             continue
 
         if char == "\\":

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -111,10 +111,80 @@ def _regex_transformer(value: str) -> Pattern[str]:
         raise argparse.ArgumentTypeError(msg) from e
 
 
+def _split_regex_csv(value: str) -> Sequence[str]:
+    """Split ``value`` on commas outside character classes and braces."""
+    parts: list[str] = []
+    buffer: list[str] = []
+    in_char_class = False
+    brace_stack: list[bool] = []
+    escaped = False
+
+    for char in value:
+        if escaped:
+            buffer.append(char)
+            escaped = False
+            continue
+
+        if char == "\\":
+            buffer.append(char)
+            escaped = True
+            continue
+
+        if char == "[" and not in_char_class:
+            in_char_class = True
+            buffer.append(char)
+            continue
+
+        if char == "]" and in_char_class:
+            in_char_class = False
+            buffer.append(char)
+            continue
+
+        if char == "{" and not in_char_class:
+            brace_stack.append(False)
+            buffer.append(char)
+            continue
+
+        if char == "}" and not in_char_class and brace_stack:
+            brace_stack.pop()
+            buffer.append(char)
+            continue
+
+        if char == "," and not in_char_class:
+            if not brace_stack:
+                segment = "".join(buffer).strip()
+                if segment:
+                    parts.append(segment)
+                buffer.clear()
+                continue
+            brace_stack[-1] = True
+
+        buffer.append(char)
+
+    segment = "".join(buffer).strip()
+    if segment:
+        parts.append(segment)
+
+    if in_char_class:
+        raise argparse.ArgumentTypeError(
+            f"Error in provided regular expression: {value} contains an unterminated character class"
+        )
+    if brace_stack and any(brace_stack):
+        raise argparse.ArgumentTypeError(
+            f"Error in provided regular expression: {value} contains unbalanced braces"
+        )
+    if escaped:
+        raise argparse.ArgumentTypeError(
+            f"Error in provided regular expression: {value} has an unfinished escape sequence"
+        )
+
+    return parts
+
+
 def _regexp_csv_transfomer(value: str) -> Sequence[Pattern[str]]:
     """Transforms a comma separated list of regular expressions."""
     patterns: list[Pattern[str]] = []
-    for pattern in _csv_transformer(value):
+    for pattern in _split_regex_csv(value):
         patterns.append(_regex_transformer(pattern))
     return patterns
 
@@ -122,14 +192,13 @@ def _regexp_csv_transfomer(value: str) -> Sequence[Pattern[str]]:
 def _regexp_paths_csv_transfomer(value: str) -> Sequence[Pattern[str]]:
     """Transforms a comma separated list of regular expressions paths."""
     patterns: list[Pattern[str]] = []
-    for pattern in _csv_transformer(value):
-        patterns.append(
-            re.compile(
-                str(pathlib.PureWindowsPath(pattern)).replace("\\", "\\\\")
-                + "|"
-                + pathlib.PureWindowsPath(pattern).as_posix()
-            )
+    for pattern in _split_regex_csv(value):
+        compiled_pattern = (
+            str(pathlib.PureWindowsPath(pattern)).replace("\\", "\\\\")
+            + "|"
+            + pathlib.PureWindowsPath(pattern).as_posix()
         )
+        patterns.append(_regex_transformer(compiled_pattern))
     return patterns
 
 

--- a/pylint/config/argument.py
+++ b/pylint/config/argument.py
@@ -111,18 +111,71 @@ def _regex_transformer(value: str) -> Pattern[str]:
         raise argparse.ArgumentTypeError(msg) from e
 
 
+class _CharClassTracker:
+    """Track character class parsing state for regex CSV splitting."""
+
+    def __init__(self) -> None:
+        self.active = False
+        self.position = 0
+        self.first_char: str | None = None
+
+    def try_enter(self, char: str, buffer: list[str]) -> bool:
+        if char == "[" and not self.active:
+            self.active = True
+            self.position = 0
+            self.first_char = None
+            buffer.append(char)
+            return True
+        return False
+
+    def record_literal(self, char: str) -> None:
+        if not self.active:
+            return
+        if self.position == 0:
+            self.first_char = char
+        self.position += 1
+
+    def consume(self, char: str, buffer: list[str]) -> bool:
+        if not self.active:
+            return False
+        if char == "]":
+            if self.position == 0 or (
+                self.position == 1 and self.first_char == "^"
+            ):
+                buffer.append(char)
+                self.record_literal(char)
+                return True
+            buffer.append(char)
+            self.active = False
+            self.position = 0
+            self.first_char = None
+            return True
+        buffer.append(char)
+        self.record_literal(char)
+        return True
+
+    def ensure_closed(self, value: str) -> None:
+        if self.active:
+            raise argparse.ArgumentTypeError(
+                "Error in provided regular expression: "
+                f"{value} contains an unterminated character class"
+            )
+
+
 def _split_regex_csv(value: str) -> Sequence[str]:
     """Split ``value`` on commas outside character classes and braces."""
     parts: list[str] = []
     buffer: list[str] = []
-    in_char_class = False
-    brace_stack: list[bool] = []
+    char_class = _CharClassTracker()
+    brace_depth = 0
     escaped = False
 
     for char in value:
         if escaped:
             buffer.append(char)
             escaped = False
+            if char_class.active:
+                char_class.record_literal(char)
             continue
 
         if char == "\\":
@@ -130,34 +183,29 @@ def _split_regex_csv(value: str) -> Sequence[str]:
             escaped = True
             continue
 
-        if char == "[" and not in_char_class:
-            in_char_class = True
+        if char_class.try_enter(char, buffer):
+            continue
+
+        if char_class.consume(char, buffer):
+            continue
+
+        if char == "{" and not char_class.active:
+            brace_depth += 1
             buffer.append(char)
             continue
 
-        if char == "]" and in_char_class:
-            in_char_class = False
+        if char == "}" and not char_class.active and brace_depth > 0:
+            brace_depth -= 1
             buffer.append(char)
             continue
 
-        if char == "{" and not in_char_class:
-            brace_stack.append(False)
-            buffer.append(char)
-            continue
-
-        if char == "}" and not in_char_class and brace_stack:
-            brace_stack.pop()
-            buffer.append(char)
-            continue
-
-        if char == "," and not in_char_class:
-            if not brace_stack:
+        if char == "," and not char_class.active:
+            if brace_depth == 0:
                 segment = "".join(buffer).strip()
                 if segment:
                     parts.append(segment)
                 buffer.clear()
                 continue
-            brace_stack[-1] = True
 
         buffer.append(char)
 
@@ -165,11 +213,9 @@ def _split_regex_csv(value: str) -> Sequence[str]:
     if segment:
         parts.append(segment)
 
-    if in_char_class:
-        raise argparse.ArgumentTypeError(
-            f"Error in provided regular expression: {value} contains an unterminated character class"
-        )
-    if brace_stack and any(brace_stack):
+    char_class.ensure_closed(value)
+
+    if brace_depth:
         raise argparse.ArgumentTypeError(
             f"Error in provided regular expression: {value} contains unbalanced braces"
         )
@@ -551,7 +597,7 @@ class _CallableArgument(_Argument):
         kwargs: dict[str, Any],
         hide_help: bool,
         section: str | None,
-        metavar: str,
+        metavar: str | None = None,
     ) -> None:
         super().__init__(
             flags=flags, arg_help=arg_help, hide_help=hide_help, section=section

--- a/tests/config/test_argument_transformers.py
+++ b/tests/config/test_argument_transformers.py
@@ -37,6 +37,13 @@ def test_regexp_csv_comma_inside_character_class() -> None:
     assert patterns[0].pattern == "prefix[a,b]suffix"
 
 
+def test_regexp_csv_character_class_with_leading_closing_bracket() -> None:
+    patterns = _regexp_csv_transfomer("[],]")
+
+    assert len(patterns) == 1
+    assert patterns[0].pattern == "[],]"
+
+
 def test_regexp_csv_escaped_comma() -> None:
     patterns = _regexp_csv_transfomer(r"foo\,,bar")
 

--- a/tests/config/test_argument_transformers.py
+++ b/tests/config/test_argument_transformers.py
@@ -44,6 +44,13 @@ def test_regexp_csv_character_class_with_leading_closing_bracket() -> None:
     assert patterns[0].pattern == "[],]"
 
 
+def test_regexp_csv_character_class_with_escaped_caret() -> None:
+    patterns = _regexp_csv_transfomer(r"[\^]")
+
+    assert len(patterns) == 1
+    assert patterns[0].pattern == r"[\^]"
+
+
 def test_regexp_csv_escaped_comma() -> None:
     patterns = _regexp_csv_transfomer(r"foo\,,bar")
 

--- a/tests/config/test_argument_transformers.py
+++ b/tests/config/test_argument_transformers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from pylint.config.argument import (
+    _regexp_csv_transfomer,
+    _regexp_paths_csv_transfomer,
+)
+
+
+def test_regexp_csv_with_quantifier_group() -> None:
+    patterns = _regexp_csv_transfomer("(foo{1,3})")
+
+    assert len(patterns) == 1
+    assert patterns[0].pattern == "(foo{1,3})"
+
+
+def test_regexp_csv_with_simple_separator() -> None:
+    patterns = _regexp_csv_transfomer("foo,bar")
+
+    assert [pattern.pattern for pattern in patterns] == ["foo", "bar"]
+
+
+def test_regexp_csv_invalid_expression_raises_argparse_error() -> None:
+    with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+        _regexp_csv_transfomer("foo{1,3")
+
+    assert "Error in provided regular expression" in str(excinfo.value)
+
+
+def test_regexp_csv_comma_inside_character_class() -> None:
+    patterns = _regexp_csv_transfomer("prefix[a,b]suffix")
+
+    assert len(patterns) == 1
+    assert patterns[0].pattern == "prefix[a,b]suffix"
+
+
+def test_regexp_csv_escaped_comma() -> None:
+    patterns = _regexp_csv_transfomer(r"foo\,,bar")
+
+    assert [pattern.pattern for pattern in patterns] == [r"foo\,", "bar"]
+
+
+def test_regexp_paths_csv_handles_quantifier_and_separator() -> None:
+    patterns = _regexp_paths_csv_transfomer("dir{1,3},other")
+
+    assert [pattern.pattern for pattern in patterns] == [
+        "dir{1,3}|dir{1,3}",
+        "other|other",
+    ]


### PR DESCRIPTION
## Summary
- add a targeted splitter for regexp_csv and regexp_paths_csv that ignores commas in escaped contexts, character classes, and brace quantifiers
- surface argparse.ArgumentTypeError for unterminated character classes and brace quantifiers before compiling
- add unit tests covering quantifiers, escaped commas, and paths (#36)

## Observed failure
```
Traceback (most recent call last):
  File "/home/lihu/.venv/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
  File "/home/lihu/.venv/lib/python3.10/site-packages/pylint/__init__.py", line 25, in run_pylint
    PylintRun(argv or sys.argv[1:])
  File "/home/lihu/.venv/lib/python3.10/site-packages/pylint/lint/run.py", line 161, in __init__
    args = _config_initialization(
  File "/home/lihu/.venv/lib/python3.10/site-packages/pylint/config/config_initialization.py", line 57, in _config_initialization
    linter._parse_configuration_file(config_args)
  File "/home/lihu/.venv/lib/python3.10/site-packages/pylint/config/arguments_manager.py", line 244, in _parse_configuration_file
    self.config, parsed_args = self._arg_parser.parse_known_args(
  File "/usr/lib/python3.10/argparse.py", line 1870, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python3.10/argparse.py", line 2079, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python3.10/argparse.py", line 2019, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python3.10/argparse.py", line 1931, in take_action
    argument_values = self._get_values(action, argument_strings)
  File "/usr/lib/python3.10/argparse.py", line 2462, in _get_values
    value = self._get_value(action, arg_string)
  File "/usr/lib/python3.10/argparse.py", line 2495, in _get_value
    result = type_func(arg_string)
  File "/home/lihu/.venv/lib/python3.10/site-packages/pylint/config/argument.py", line 106, in _regexp_csv_transfomer
    patterns.append(re.compile(pattern))
  File "/usr/lib/python3.10/re.py", line 251, in compile
    return _compile(pattern, flags)
  File "/usr/lib/python3.10/re.py", line 303, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib/python3.10/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib/python3.10/sre_parse.py", line 950, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib/python3.10/sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "/usr/lib/python3.10/sre_parse.py", line 838, in _parse
    raise source.error("missing ), unterminated subpattern",
re.error: missing ), unterminated subpattern at position 0
```

## Reproduction
1. Configure `[tool.pylint.basic] bad-name-rgxs = "(foo{1,3})"` in pyproject.toml (or equivalent)
2. Run `pylint foo.py`
3. Observe pylint crash during configuration parsing

## Limitations
- The splitter only guards escaped commas, character classes, and brace-style quantifiers; it is not a complete regex parser.
- Literal single `{` characters without escaping remain permitted but are not treated specially.