### PR TITLE
Respect ignores in recursive mode (swev-id: pylint-dev__pylint-6528)

### DIFF
--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -14,6 +14,7 @@ import traceback
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
+from pathlib import Path
 from io import TextIOWrapper
 from typing import Any
 
@@ -564,30 +565,84 @@ class PyLinter(
             if not msg.may_be_emitted():
                 self._msgs_state[msg.msgid] = False
 
-    @staticmethod
-    def _discover_files(files_or_modules: Sequence[str]) -> Iterator[str]:
+    def _should_ignore_path(self, path: str, is_dir: bool) -> bool:
+        """Return True if *path* should be skipped during recursive discovery."""
+
+        normalized_path = os.path.normpath(os.path.abspath(path))
+        path_obj = Path(normalized_path)
+
+        segments = (
+            segment
+            for segment in path_obj.parts
+            if segment and segment != path_obj.anchor
+        )
+        for segment in segments:
+            if segment in self.config.ignore:
+                return True
+            if any(pattern.match(segment) for pattern in self.config.ignore_patterns):
+                return True
+
+        path_candidates = [normalized_path]
+        if is_dir and not normalized_path.endswith(os.sep):
+            path_candidates.append(f"{normalized_path}{os.sep}")
+
+        if os.sep != "/":
+            normalized_posix = normalized_path.replace(os.sep, "/")
+            path_candidates.append(normalized_posix)
+            if is_dir and not normalized_posix.endswith("/"):
+                path_candidates.append(f"{normalized_posix}/")
+
+        if any(
+            pattern.match(candidate)
+            for candidate in path_candidates
+            for pattern in self.config.ignore_paths
+        ):
+            return True
+
+        return False
+
+    def _discover_files(self, files_or_modules: Sequence[str]) -> Iterator[str]:
         """Discover python modules and packages in sub-directory.
 
         Returns iterator of paths to discovered modules and packages.
         """
         for something in files_or_modules:
-            if os.path.isdir(something) and not os.path.isfile(
+            is_directory = os.path.isdir(something)
+            if self._should_ignore_path(something, is_directory):
+                continue
+
+            if is_directory and not os.path.isfile(
                 os.path.join(something, "__init__.py")
             ):
                 skip_subtrees: list[str] = []
-                for root, _, files in os.walk(something):
-                    if any(root.startswith(s) for s in skip_subtrees):
-                        # Skip subtree of already discovered package.
+                for root, dirs, files in os.walk(something):
+                    normalized_root = os.path.normpath(root)
+                    if any(normalized_root.startswith(prefix) for prefix in skip_subtrees):
                         continue
-                    if "__init__.py" in files:
-                        skip_subtrees.append(root)
-                        yield root
-                    else:
-                        yield from (
-                            os.path.join(root, file)
-                            for file in files
-                            if file.endswith(".py")
+                    if self._should_ignore_path(normalized_root, True):
+                        dirs[:] = []
+                        continue
+
+                    dirs[:] = [
+                        directory
+                        for directory in dirs
+                        if not self._should_ignore_path(
+                            os.path.join(root, directory), True
                         )
+                    ]
+
+                    if "__init__.py" in files:
+                        skip_subtrees.append(normalized_root)
+                        yield root
+                        continue
+
+                    for file in files:
+                        if not file.endswith(".py"):
+                            continue
+                        file_path = os.path.join(root, file)
+                        if self._should_ignore_path(file_path, False):
+                            continue
+                        yield file_path
             else:
                 yield something
 
@@ -605,7 +660,11 @@ class PyLinter(
             )
             files_or_modules = (files_or_modules,)  # type: ignore[assignment]
         if self.config.recursive:
-            files_or_modules = tuple(self._discover_files(files_or_modules))
+            files_or_modules = tuple(
+                path
+                for path in self._discover_files(files_or_modules)
+                if not self._should_ignore_path(path, os.path.isdir(path))
+            )
         if self.config.from_stdin:
             if len(files_or_modules) != 1:
                 raise exceptions.InvalidArgsError(

--- a/pylint/lint/pylinter.py
+++ b/pylint/lint/pylinter.py
@@ -565,18 +565,30 @@ class PyLinter(
             if not msg.may_be_emitted():
                 self._msgs_state[msg.msgid] = False
 
-    def _should_ignore_path(self, path: str, is_dir: bool) -> bool:
+    def _should_ignore_path(
+        self, path: str, is_dir: bool, *, root: str | None = None
+    ) -> bool:
         """Return True if *path* should be skipped during recursive discovery."""
 
         normalized_path = os.path.normpath(os.path.abspath(path))
-        path_obj = Path(normalized_path)
 
-        segments = (
-            segment
-            for segment in path_obj.parts
-            if segment and segment != path_obj.anchor
-        )
-        for segment in segments:
+        relative_segments: tuple[str, ...] = ()
+        if root is not None:
+            normalized_root = os.path.normpath(os.path.abspath(root))
+            try:
+                common_path = os.path.commonpath([normalized_root, normalized_path])
+            except ValueError:
+                common_path = None
+            if common_path == normalized_root:
+                rel = os.path.relpath(normalized_path, start=normalized_root)
+                if rel not in (".", ""):
+                    relative_segments = tuple(
+                        segment
+                        for segment in Path(rel).parts
+                        if segment not in ("", ".", os.pardir)
+                    )
+
+        for segment in relative_segments:
             if segment in self.config.ignore:
                 return True
             if any(pattern.match(segment) for pattern in self.config.ignore_patterns):
@@ -592,12 +604,10 @@ class PyLinter(
             if is_dir and not normalized_posix.endswith("/"):
                 path_candidates.append(f"{normalized_posix}/")
 
-        if any(
-            pattern.match(candidate)
-            for candidate in path_candidates
-            for pattern in self.config.ignore_paths
-        ):
-            return True
+        for candidate in path_candidates:
+            for pattern in self.config.ignore_paths:
+                if pattern.match(candidate):
+                    return True
 
         return False
 
@@ -608,7 +618,16 @@ class PyLinter(
         """
         for something in files_or_modules:
             is_directory = os.path.isdir(something)
-            if self._should_ignore_path(something, is_directory):
+            normalized_root = (
+                os.path.normpath(os.path.abspath(something))
+                if os.path.exists(something)
+                else None
+            )
+            if self._should_ignore_path(
+                something,
+                is_directory,
+                root=normalized_root if normalized_root is not None else None,
+            ):
                 continue
 
             if is_directory and not os.path.isfile(
@@ -616,10 +635,17 @@ class PyLinter(
             ):
                 skip_subtrees: list[str] = []
                 for root, dirs, files in os.walk(something):
-                    normalized_root = os.path.normpath(root)
-                    if any(normalized_root.startswith(prefix) for prefix in skip_subtrees):
+                    normalized_root_dir = os.path.normpath(root)
+                    if any(
+                        normalized_root_dir.startswith(prefix)
+                        for prefix in skip_subtrees
+                    ):
                         continue
-                    if self._should_ignore_path(normalized_root, True):
+                    if self._should_ignore_path(
+                        normalized_root_dir,
+                        True,
+                        root=normalized_root,
+                    ):
                         dirs[:] = []
                         continue
 
@@ -627,12 +653,14 @@ class PyLinter(
                         directory
                         for directory in dirs
                         if not self._should_ignore_path(
-                            os.path.join(root, directory), True
+                            os.path.join(root, directory),
+                            True,
+                            root=normalized_root,
                         )
                     ]
 
                     if "__init__.py" in files:
-                        skip_subtrees.append(normalized_root)
+                        skip_subtrees.append(normalized_root_dir)
                         yield root
                         continue
 
@@ -640,7 +668,9 @@ class PyLinter(
                         if not file.endswith(".py"):
                             continue
                         file_path = os.path.join(root, file)
-                        if self._should_ignore_path(file_path, False):
+                        if self._should_ignore_path(
+                            file_path, False, root=normalized_root
+                        ):
                             continue
                         yield file_path
             else:
@@ -660,11 +690,7 @@ class PyLinter(
             )
             files_or_modules = (files_or_modules,)  # type: ignore[assignment]
         if self.config.recursive:
-            files_or_modules = tuple(
-                path
-                for path in self._discover_files(files_or_modules)
-                if not self._should_ignore_path(path, os.path.isdir(path))
-            )
+            files_or_modules = tuple(self._discover_files(files_or_modules))
         if self.config.from_stdin:
             if len(files_or_modules) != 1:
                 raise exceptions.InvalidArgsError(

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -107,6 +107,38 @@ def tempdir() -> Iterator[str]:
         rmtree(abs_tmp)
 
 
+def _create_recursive_linter_for_test(
+    *,
+    ignore: Iterable[str] | None = None,
+    ignore_patterns: Iterable[re.Pattern[str]] | None = None,
+    ignore_paths: Iterable[re.Pattern[str]] | None = None,
+) -> PyLinter:
+    reporter = testutils.GenericTestReporter()
+    linter = PyLinter()
+    linter.set_reporter(reporter)
+    linter.config.persistent = 0
+    checkers.initialize(linter)
+    linter.config.recursive = True
+
+    ignore_list = list(linter.config.ignore)
+    if ignore:
+        ignore_list.extend(ignore)
+    linter.config.ignore = ignore_list
+
+    pattern_list = list(linter.config.ignore_patterns)
+    if ignore_patterns:
+        pattern_list.extend(ignore_patterns)
+    linter.config.ignore_patterns = pattern_list
+
+    path_pattern_list = list(linter.config.ignore_paths)
+    if ignore_paths:
+        path_pattern_list.extend(ignore_paths)
+    linter.config.ignore_paths = path_pattern_list
+
+    linter.open()
+    return linter
+
+
 @pytest.fixture
 def fake_path() -> Iterator[Iterable[str]]:
     orig = list(sys.path)
@@ -796,6 +828,80 @@ def test_custom_should_analyze_file() -> None:
         messages = reporter.messages
         assert len(messages) == 1
         assert "invalid syntax" in messages[0].msg
+
+
+def test_recursive_respects_ignore_patterns(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    hidden_dir = project / ".a"
+    hidden_dir.mkdir()
+    (hidden_dir / "foo.py").write_text("x = 1\n", encoding="utf-8")
+    (project / "bar.py").write_text("x = 1\n", encoding="utf-8")
+
+    linter = _create_recursive_linter_for_test(
+        ignore_patterns=[re.compile(r"^\.")]
+    )
+    linter.check([str(project)])
+
+    linted_paths = {Path(msg.path).resolve() for msg in linter.reporter.messages}
+    assert (project / "bar.py").resolve() in linted_paths
+    assert (hidden_dir / "foo.py").resolve() not in linted_paths
+
+
+def test_recursive_respects_ignore(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    build_dir = project / "build"
+    build_dir.mkdir()
+    normal_dir = project / "normal"
+    normal_dir.mkdir()
+    (build_dir / "x.py").write_text("x = 1\n", encoding="utf-8")
+    (normal_dir / "y.py").write_text("x = 1\n", encoding="utf-8")
+
+    linter = _create_recursive_linter_for_test(ignore=["build"])
+    linter.check([str(project)])
+
+    linted_paths = {Path(msg.path).resolve() for msg in linter.reporter.messages}
+    assert (normal_dir / "y.py").resolve() in linted_paths
+    assert (build_dir / "x.py").resolve() not in linted_paths
+
+
+def test_recursive_respects_ignore_paths(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    pkg_dir = project / "pkg"
+    pkg_dir.mkdir()
+    secret_dir = pkg_dir / "secret"
+    secret_dir.mkdir()
+    public_dir = pkg_dir / "public"
+    public_dir.mkdir()
+    (secret_dir / "foo.py").write_text("x = 1\n", encoding="utf-8")
+    (public_dir / "bar.py").write_text("x = 1\n", encoding="utf-8")
+
+    linter = _create_recursive_linter_for_test(
+        ignore_paths=[re.compile(r".*/secret/.*")]
+    )
+    linter.check([str(project)])
+
+    linted_paths = {Path(msg.path).resolve() for msg in linter.reporter.messages}
+    assert (public_dir / "bar.py").resolve() in linted_paths
+    assert (secret_dir / "foo.py").resolve() not in linted_paths
+
+
+def test_recursive_ignores_package_subdirectories(tmp_path: Path) -> None:
+    package = tmp_path / "pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text("x = 1\n", encoding="utf-8")
+    ignored_dir = package / "ignored_dir"
+    ignored_dir.mkdir()
+    (ignored_dir / "z.py").write_text("x = 1\n", encoding="utf-8")
+
+    linter = _create_recursive_linter_for_test(ignore=["ignored_dir"])
+    linter.check([str(package)])
+
+    linted_paths = {Path(msg.path).resolve() for msg in linter.reporter.messages}
+    assert (package / "__init__.py").resolve() in linted_paths
+    assert (ignored_dir / "z.py").resolve() not in linted_paths
 
 
 # we do the check with jobs=1 as well, so that we are sure that the duplicates

--- a/tests/lint/unittest_lint.py
+++ b/tests/lint/unittest_lint.py
@@ -904,6 +904,24 @@ def test_recursive_ignores_package_subdirectories(tmp_path: Path) -> None:
     assert (ignored_dir / "z.py").resolve() not in linted_paths
 
 
+def test_recursive_ignore_respects_parent_named_tmp(tmp_path: Path) -> None:
+    outer_tmp = tmp_path / "tmp"
+    project = outer_tmp / "project"
+    outer_tmp.mkdir()
+    project.mkdir()
+    (project / "root_file.py").write_text("x = 1\n", encoding="utf-8")
+    nested_tmp = project / "tmp"
+    nested_tmp.mkdir()
+    (nested_tmp / "ignored.py").write_text("x = 1\n", encoding="utf-8")
+
+    linter = _create_recursive_linter_for_test(ignore=["tmp"])
+    linter.check([str(project)])
+
+    linted_paths = {Path(msg.path).resolve() for msg in linter.reporter.messages}
+    assert (project / "root_file.py").resolve() in linted_paths
+    assert (nested_tmp / "ignored.py").resolve() not in linted_paths
+
+
 # we do the check with jobs=1 as well, so that we are sure that the duplicates
 # are created by the multiprocessing problem.
 @pytest.mark.needs_two_cores


### PR DESCRIPTION
## Summary
- add a path-aware `_should_ignore_path` to filter discovery targets before linting
- skip ignored directories while walking recursively to avoid traversing their subtrees
- add regression coverage exercising ignore, ignore-patterns, and ignore-paths in recursive runs

## Reproduction (base branch)
Commands:
```bash
python -m pylint --recursive=y .
python -m pylint --recursive=y --ignore=.a .
python -m pylint --recursive=y --ignore-paths=.a .
python -m pylint --recursive=y --ignore-patterns="^\\.a" .
```

Observed output (no stack trace):
```text
************* Module foo
.a/foo.py:1:0: C0114: Missing module docstring (missing-module-docstring)
.a/foo.py:1:0: C0104: Disallowed name "foo" (disallowed-name)
.a/foo.py:1:0: C0103: Constant name "x" doesn't conform to UPPER_CASE naming style (invalid-name)
```

## Testing
- python -m pylint pylint/lint/pylinter.py tests/lint/unittest_lint.py
- pytest tests/lint/unittest_lint.py -k recursive